### PR TITLE
pass `void*` arguments to entry function

### DIFF
--- a/examples/pingpong.c
+++ b/examples/pingpong.c
@@ -5,22 +5,22 @@
 
 #include <vireo.h>
 
-void pingpong(void);
+void pingpong(void*);
 
 void
-umain(void)
+umain(void*)
 {
-	int who = vireo_create(pingpong);
+	int who = vireo_create(pingpong, NULL);
 
 	// get the ball rolling
 	printf("send 0 from %x to %x\n", vireo_getid(), who);
 	vireo_send(who, 0);
 
-	pingpong();
+	pingpong(NULL);
 }
 
 void
-pingpong(void)
+pingpong(void*)
 {
 	int who;
 	while (1) {

--- a/examples/primes.c
+++ b/examples/primes.c
@@ -4,7 +4,7 @@
 #include <vireo.h>
 
 void
-primeproc(void)
+primeproc(void*)
 {
 	int i, id, p;
 
@@ -13,7 +13,7 @@ primeproc(void)
 	printf("%d ", p);
 
 	// fork a right neighbor to continue the chain
-	id = vireo_create(primeproc);
+	id = vireo_create(primeproc, NULL);
 	if (id == -1)
 		exit(0);
 
@@ -26,11 +26,11 @@ primeproc(void)
 }
 
 void
-umain(void)
+umain(void*)
 {
 	int i, id;
 	// fork the first prime procss in the chain
-	id = vireo_create(primeproc);
+	id = vireo_create(primeproc, NULL);
 
 	// feed all the integers through
 	for (i = 2; ; i++)

--- a/examples/spin.c
+++ b/examples/spin.c
@@ -7,7 +7,7 @@
 #include <vireo.h>
 
 void
-child(void)
+child(void*)
 {
 	printf("I am the child.  Spinning...\n");
 	while (1)
@@ -15,12 +15,12 @@ child(void)
 }
 
 void
-umain(void)
+umain(void*)
 {
 	int env;
 
 	printf("I am the parent.  Forking the child...\n");
-	env = vireo_create(child);
+	env = vireo_create(child, NULL);
 
 	printf("I am the parent.  Running the child...\n");
 	vireo_yield();

--- a/examples/yield.c
+++ b/examples/yield.c
@@ -3,7 +3,7 @@
 #include <vireo.h>
 
 static void
-yield_thread(void)
+yield_thread(void*)
 {
 	int i;
 
@@ -17,11 +17,11 @@ yield_thread(void)
 }
 
 void
-umain(void)
+umain(void*)
 {
 	int i;
 	for (i = 0; i < 3; i++) {
-		vireo_create(yield_thread);
+		vireo_create(yield_thread, NULL);
 	}
 	vireo_exit();
 }

--- a/vireo.c
+++ b/vireo.c
@@ -61,7 +61,7 @@ typedef struct Env {
 static Env envs[NENV];
 static int curenv;
 
-void umain(void); /* provided by user */
+void umain(void*); /* provided by user */
 
 /* Define a "successor context" for the purpose of calling env_exit */
 static ucontext_t exiter = {0};
@@ -88,7 +88,7 @@ make_stack(ucontext_t *ucp)
 }
 
 int
-vireo_create(vireo_entry entry)
+vireo_create(vireo_entry entry, void* args)
 {
 	// Find an available environment
 	int env;
@@ -107,7 +107,7 @@ vireo_create(vireo_entry entry)
 	getcontext(&envs[env].state);
 	make_stack(&envs[env].state);
 	envs[env].state.uc_link = &exiter;
-	makecontext(&envs[env].state, entry, 0);
+	makecontext(&envs[env].state, (void (*)(void))entry, 1, args);
 	// Creation worked. Yay.
 	return env;
 }
@@ -214,7 +214,7 @@ initialize_threads(vireo_entry new_main)
 	make_stack(&exiter);
 	makecontext(&exiter, vireo_exit, 0);
 
-	vireo_create(new_main);
+	vireo_create(new_main, NULL);
 	setcontext(&envs[curenv].state);
 }
 

--- a/vireo.h
+++ b/vireo.h
@@ -8,12 +8,12 @@
 #include <ucontext.h>
 
 // Start point of the green thread
-typedef void (*vireo_entry)(void);
+typedef void (*vireo_entry)(void* args);
 
 // Create (and mark as runnable) a new green thread. Will not be run
 // until at least the next call to env_yield(). Returns an identifier
 // for the green thread, or -1 if no new green thread can be created.
-int vireo_create(vireo_entry entry);
+int vireo_create(vireo_entry entry, void* args);
 
 // Yield to the next available green thread, possibly the current one
 void vireo_yield(void);


### PR DESCRIPTION
Based on documentation for `makecontext` this _appears_ to be the correct implementation, but there may be some glibc-specific behavior greasing the wheels here. `makecontext` initially suggests only `int`-sized arguments can be passed to the given function, but quickly makes mentions glibc has some accomodations for x86 systems. Additionally, the type-checker complained about the type of the entry function; seeminly at odds with the documentation. In any case, this seems to work as expected.