### PR TITLE
Implement sleep example

### DIFF
--- a/examples/sleep.c
+++ b/examples/sleep.c
@@ -1,0 +1,61 @@
+#include <stdio.h>
+#include <unistd.h>
+#include <time.h>
+
+#include <vireo.h>
+
+void
+sleep_(int seconds)
+{
+    struct timespec time = {0};
+    clock_gettime(CLOCK_MONOTONIC, &time);
+    time.tv_sec += seconds;
+
+    int result;
+    do {
+        result = clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &time, NULL);
+    } while (result != 0);
+}
+
+typedef struct {
+    int seconds;
+    int who;
+} Arg;
+
+void
+child(void* args)
+{
+    int seconds = ((Arg*)args)->seconds;
+    int who = ((Arg*)args)->who;
+    printf("   - child [%d] thread sleeping for %d seconds\n", who, seconds);
+    sleep_(seconds);
+    printf("   - child [%d] thread has awoken\n", who);
+}
+
+#define N 3
+
+void
+umain(void*)
+{
+    printf(" - parent thread yield\n");
+    vireo_yield();
+
+    int envs[N];
+    Arg args[N];
+
+    printf(" - creating child threads\n");
+    for (int i = 0; i < N; ++i) {
+        envs[i] = vireo_create(child, (void*)&args[i]);
+        args[i].seconds = N - i;
+        args[i].who = envs[i];
+    }
+
+    int seconds = N + 1;
+    printf(" - parent thread sleeping for %d seconds\n", seconds);
+    sleep_(seconds);
+
+    printf(" - destroying child threads\n");
+    for (int i = 0; i < N; ++i) {
+        vireo_destroy(envs[i]);
+    }
+}

--- a/vireo.c
+++ b/vireo.c
@@ -202,7 +202,7 @@ enable_preemption(void)
 
 	sigemptyset(&act.sa_mask);
 	sigaction(TIMERSIG, &act, NULL);
-	timer_create(CLOCK_PROCESS_CPUTIME_ID, &sigev, &timer);
+	timer_create(CLOCK_MONOTONIC, &sigev, &timer);
 }
 
 static void


### PR DESCRIPTION
Initial tests with the previous timer did not work as expected since sleeping a process did not result in accumulation of `PROCESS_CPU`-time. The goal here was to support multiple threads sleeping _concurrently_; the fix being to switch to a `MONOTONIC` timer. While this achieves the desired effect, I'm not 100% the overall impact on moving off of the previous timer, perhaps there were some additional reasons to make use of that original clock.